### PR TITLE
Change uninterpretable difference-score to z-score

### DIFF
--- a/R/normcomp.R
+++ b/R/normcomp.R
@@ -78,7 +78,7 @@ normcomp <- function( myJSON){
     Tsquared <- ( 1 / g ) * ( ( min.est.n - P ) / ( ( min.est.n - 1 ) * P ) ) * t( mydata[['pred']] - mydata[['score']] ) %*% inv.C %*% ( mydata[['pred']] - mydata[['score']] )
 
     tstatistics <- ((mydata[['score']] - mydata[['pred']]) / ( sqrt(diag(C)) / sqrt(est.n))) * (1 / sqrt(est.n + 1))
-    difference <- (mydata[['score']] - mydata[['pred']])
+    difference <- (mydata[['score']] - mydata[['pred']]) / sqrt(diag(C))
 
     tailed <- mydata[['sig']][1]
     if( tailed == "oneTailedLeft"){


### PR DESCRIPTION
This does affect the calculation of the p-value for the one-sided comparisons (makes it better, as all tests are now weighted equally), but that is internal to this function.

This should not interfere with any one other code (just marginally changes values) so merging should be innocuous.
